### PR TITLE
Update health slider using progress bar

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -32,6 +32,10 @@ window/stretch/mode="viewport"
 window/stretch/aspect="expand"
 window/vsync/vsync_mode=0
 
+[dotnet]
+
+project/assembly_name="LibreAim"
+
 [input]
 
 ui_accept={

--- a/scenes/enemies/health_slider.gd
+++ b/scenes/enemies/health_slider.gd
@@ -1,4 +1,4 @@
-extends MeshInstance3D
+extends Sprite3D
 ## Slider that shows the health of the enemy targets
 
 var enabled: bool = false
@@ -8,15 +8,15 @@ func _process(_delta: float) -> void:
 	if enabled:
 		var health = $"..".health
 		var max_health = $"..".max_health
-		mesh.size.x = lerp(0, 3, health / max_health)
+		$HealthSliderViewport/ProgressBar.value = (health / max_health) * 100
 
 func enable() -> void:
-	visible = true
 	enabled = true
 	position.y = ($"../CollisionShape3D/MeshInstance3D".mesh.height / 2) + 0.4
+	$ColorAnimationPlayer.play("RESET")
 
 func _on_target_hitted() -> void:
 	$AudioStreamPlayer.play()
 	$AudioStreamPlayer.pitch_scale = randf_range(0.97, 1.03)
-	$AnimationPlayer.play("RESET")
-	$AnimationPlayer.play("shot")
+	$ColorAnimationPlayer.play("change_color")
+	

--- a/scenes/enemies/progress_bar.tscn
+++ b/scenes/enemies/progress_bar.tscn
@@ -1,0 +1,34 @@
+[gd_scene load_steps=3 format=3 uid="uid://bf8b30xdqlg21"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0mgcu"]
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(1, 1, 1, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_eytjc"]
+bg_color = Color(0, 0, 0, 1)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(1, 1, 1, 1)
+
+[node name="ProgressBar" type="ProgressBar"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -146.0
+offset_top = -17.5
+offset_right = 146.0
+offset_bottom = 17.5
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/background = SubResource("StyleBoxFlat_0mgcu")
+theme_override_styles/fill = SubResource("StyleBoxFlat_eytjc")
+value = 75.0
+rounded = true
+show_percentage = false

--- a/scenes/enemies/target.tscn
+++ b/scenes/enemies/target.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" path="res://scenes/enemies/target.gd" id="1_nte11"]
 [ext_resource type="Script" path="res://scenes/enemies/health_slider.gd" id="2_usxmj"]
 [ext_resource type="AudioStream" uid="uid://kf70w8cqg0y" path="res://scenes/enemies/hit.ogg" id="3_o7ev4"]
+[ext_resource type="PackedScene" uid="uid://bf8b30xdqlg21" path="res://scenes/enemies/progress_bar.tscn" id="4_5i7pn"]
 
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_do5mn"]
 height = 1.0
@@ -18,49 +19,44 @@ material = SubResource("StandardMaterial3D_nkxxc")
 height = 1.0
 radial_segments = 32
 
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_18ew3"]
-emission_enabled = true
-emission = Color(1, 1, 1, 1)
+[sub_resource type="ViewportTexture" id="ViewportTexture_fogxd"]
+viewport_path = NodePath("HealthSlider/HealthSliderViewport")
 
-[sub_resource type="PlaneMesh" id="PlaneMesh_4njml"]
-material = SubResource("StandardMaterial3D_18ew3")
-size = Vector2(3, 0.3)
-
-[sub_resource type="Animation" id="Animation_adj6b"]
+[sub_resource type="Animation" id="Animation_ry4bo"]
 length = 0.001
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath(".:mesh:material:emission")
+tracks/0/path = NodePath("HealthSliderViewport/ProgressBar:theme_override_styles/fill:bg_color")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Color(1, 1, 1, 1)]
+"values": [Color(1, 0, 0, 1)]
 }
 
-[sub_resource type="Animation" id="Animation_7m7wm"]
+[sub_resource type="Animation" id="Animation_m1o2j"]
 resource_name = "shot"
 length = 0.3
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath(".:mesh:material:emission")
+tracks/0/path = NodePath("HealthSliderViewport/ProgressBar:theme_override_styles/fill:bg_color")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
 "times": PackedFloat32Array(0, 0.1, 0.3),
-"transitions": PackedFloat32Array(-2, -2, -2),
+"transitions": PackedFloat32Array(1, 1, 1),
 "update": 0,
-"values": [Color(1, 0.294118, 0.360784, 1), Color(1, 0.294118, 0.360784, 1), Color(1, 1, 1, 1)]
+"values": [Color(0.339735, 3.33907e-07, 1.08294e-07, 1), Color(0.341176, 0, 0, 1), Color(1, 0, 0, 1)]
 }
 
-[sub_resource type="AnimationLibrary" id="AnimationLibrary_nqfqo"]
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_r7684"]
 _data = {
-"RESET": SubResource("Animation_adj6b"),
-"shot": SubResource("Animation_7m7wm")
+"RESET": SubResource("Animation_ry4bo"),
+"change_color": SubResource("Animation_m1o2j")
 }
 
 [node name="Target" type="CharacterBody3D" groups=["Enemy"]]
@@ -75,19 +71,25 @@ shape = SubResource("CapsuleShape3D_do5mn")
 mesh = SubResource("CapsuleMesh_xrxto")
 skeleton = NodePath("../..")
 
-[node name="HealthSlider" type="MeshInstance3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.7, 0)
-mesh = SubResource("PlaneMesh_4njml")
+[node name="HealthSlider" type="Sprite3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.2737, 0)
+billboard = 1
+texture = SubResource("ViewportTexture_fogxd")
 script = ExtResource("2_usxmj")
-
-[node name="AnimationPlayer" type="AnimationPlayer" parent="HealthSlider"]
-libraries = {
-"": SubResource("AnimationLibrary_nqfqo")
-}
-autoplay = "RESET"
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="HealthSlider"]
 stream = ExtResource("3_o7ev4")
 volume_db = -10.0
+
+[node name="HealthSliderViewport" type="SubViewport" parent="HealthSlider"]
+disable_3d = true
+transparent_bg = true
+
+[node name="ProgressBar" parent="HealthSlider/HealthSliderViewport" instance=ExtResource("4_5i7pn")]
+
+[node name="ColorAnimationPlayer" type="AnimationPlayer" parent="HealthSlider"]
+libraries = {
+"": SubResource("AnimationLibrary_r7684")
+}
 
 [connection signal="hitted" from="." to="HealthSlider" method="_on_target_hitted"]


### PR DESCRIPTION
I've updated the health slider to use a progress bar. Now, the health slider is implemented as specified in #11 , with a grey bar behind the health bar showing the full health of the target.